### PR TITLE
fix: CSV出力のparamsカラムを各パラメータの個別カラムに展開する #8

### DIFF
--- a/src/hpo_agent/models.py
+++ b/src/hpo_agent/models.py
@@ -84,7 +84,7 @@ class TrialRecord:
         """TrialRecord を辞書に変換する。timestamp は ISO 文字列にシリアライズする。"""
         return {
             "trial_id": self.trial_id,
-            "params": self.params,
+            **self.params,
             "score": self.score,
             "tool_used": self.tool_used,
             "timestamp": self.timestamp.isoformat(),


### PR DESCRIPTION
TrialRecord.to_dict() で params 辞書を1カラムにまとめていたのを、
各パラメータを個別のカラムとして展開するよう修正する。