### PR TITLE
docs: align impl/adapter design docs with actual implementation

### DIFF
--- a/doc/impl_design.md
+++ b/doc/impl_design.md
@@ -500,8 +500,8 @@ class Supervisor:
 
     def run(self, config: HPOConfig) -> HPOResult: ...
     def _build_graph(self) -> CompiledGraph: ...
-    def _report_progress(self, state: SupervisorState) -> SupervisorState:
-        """中間レポートを生成してコンソール出力し、state.current_report を更新する。"""
+    def _tool_executor_node(self, state: SupervisorState) -> dict[str, Any]:
+        """選択されたツールを実行して試行結果を状態に追加する。中間レポート生成も担う。"""
         ...
 ```
 
@@ -575,13 +575,11 @@ sequenceDiagram
         HPOToolBase->>ModelAdapterBase: evaluate(params)
         ModelAdapterBase-->>HPOToolBase: score: float
         HPOToolBase-->>LangGraph: list[TrialRecord]
-        LangGraph->>LangGraph: SupervisorState を更新（trial_records, remaining_trials）
-        LangGraph->>Supervisor: _report_progress(state)
-        Supervisor->>ReportGenerator: generate_intermediate(trial_records, best_params, best_score)
-        ReportGenerator-->>Supervisor: intermediate_report: str
-        Supervisor->>Supervisor: logging.INFO(intermediate_report)
-        Note over Supervisor,User: 中間レポートをコンソールに出力
-        Supervisor-->>LangGraph: state（current_report 更新済み）
+        LangGraph->>LangGraph: _tool_executor_node() が SupervisorState を更新（trial_records, remaining_trials）
+        LangGraph->>ReportGenerator: generate_intermediate(trial_records, best_params, best_score)
+        ReportGenerator-->>LangGraph: intermediate_report: str
+        LangGraph->>LangGraph: logging.INFO(intermediate_report)
+        Note over LangGraph,User: 中間レポートをコンソールに出力（current_report を更新）
     end
 
     LangGraph-->>Supervisor: 最終 SupervisorState
@@ -629,8 +627,7 @@ Supervisor.run(config)
     ├── [ループ] HPOToolBase._run() → list[TrialRecord]
     │       │   ModelAdapterBase.evaluate() → float
     │       │
-    │       └── Supervisor._report_progress()
-    │               ReportGenerator.generate_intermediate() → str
+    │       └── _tool_executor_node() 内で ReportGenerator.generate_intermediate() を呼び出す
     │               logging.INFO(intermediate_report)  ─→ [コンソール出力（ユーザーが確認可能）]
     │
     └── [ループ終了後] ReportGenerator.generate_final(llm) → str
@@ -699,7 +696,8 @@ classDiagram
         -system_prompt: str
         +run(config: HPOConfig) HPOResult
         -_build_graph() CompiledGraph
-        -_report_progress(state: SupervisorState) SupervisorState
+        -_supervisor_node(state: SupervisorState) dict
+        -_tool_executor_node(state: SupervisorState) dict
     }
 
     class SupervisorState {
@@ -891,7 +889,7 @@ classDiagram
 | LightGBM パラメータ空間 | LightGBM のデフォルト空間は廃止。`param_space` 未指定時は LLM が自動生成する（全モデル統一の方針） | `HPOAgent._generate_param_space()` |
 | 同期実行の保証 | `HPOAgent.run()` は同期ブロッキングとする。LangGraph の非同期 API は使用しない（将来拡張への考慮のみ） | `HPOAgent.run()` |
 | ログ出力 | 各試行の実行後に試行番号・スコア・評価時間・パラメータを `logging.INFO` で出力する。ツール完了時にはツール名・試行数・最良スコア・中間レポートを `logging.INFO` で出力する | `HPOToolBase._run()`, `Supervisor._tool_executor_node()` |
-| 中間レポートの出力タイミング | ツール実行が完了し `SupervisorState` が更新されたタイミングで `_report_progress()` を呼び出す。LLM を使用しないため低コスト | `Supervisor._report_progress()` |
+| 中間レポートの出力タイミング | ツール実行が完了し `SupervisorState` が更新されたタイミングで `_tool_executor_node()` 内から `ReportGenerator.generate_intermediate()` を直接呼び出す。LLM を使用しないため低コスト | `Supervisor._tool_executor_node()` |
 | 中間レポートと最終レポートの違い | 中間レポートは現時点の統計サマリーのみ（LLM なし）。最終レポートのみ AI による考察・推薦コメントを含む（LLM あり） | `ReportGenerator.generate_intermediate()` / `generate_final()` |
 | モデルのディープコピー | 複数試行で同一モデルオブジェクトを汚染しないよう、評価前に `copy.deepcopy(model)` を行う | `ModelAdapterBase.evaluate()` |
 | 時間計測の方法 | `time.perf_counter()` を使用して `algo_duration`（アルゴリズムの提案計算時間）と `eval_duration`（モデル評価時間）を別々に計測し、`TrialRecord` に記録する。`datetime.now()` は壁時計時刻（`timestamp` 用）、`time.perf_counter()` は高精度な経過時間計測に使用する | `HPOToolBase._run()`, `ModelAdapterBase.evaluate()` |

--- a/doc/model_adapter_design.md
+++ b/doc/model_adapter_design.md
@@ -91,10 +91,10 @@ class ModelAdapterBase(ABC):
 HPOConfig.param_space が指定されている
     → ユーザー指定の ParamSpace を使用（アダプターのデフォルトは無視）
 HPOConfig.param_space が None（未指定）
-    → ModelAdapterBase.get_default_param_space() の返り値を使用
+    → HPOAgent._generate_param_space() で LLM が自動生成した ParamSpace を使用
 ```
 
-この解決は `HPOAgent._resolve_adapter()` で行い、決定した `ParamSpace` をツールに渡す。
+`_resolve_adapter()` は `(adapter, param_space)` のタプルを返す。`param_space` が `None`（未指定）の場合、呼び出し元の `HPOAgent.run()` が `_generate_param_space()` を呼び出して LLM に空間を生成させる。全モデル種別（LightGBM / sklearn / PyTorch）で統一の方針であり、アダプターのデフォルト空間（`get_default_param_space()`）は使用しない。
 
 #### `evaluate()` の契約
 
@@ -130,18 +130,9 @@ class LightGBMAdapter(ModelAdapterBase):
 
 ### 4-2. デフォルトパラメータ空間
 
-MVP では以下の8パラメータをデフォルト空間として定義する。
+`LightGBMAdapter.get_default_param_space()` は `NotImplementedError` を送出する。`param_space` 未指定時は `HPOAgent._generate_param_space()` が LLM を使って自動生成する（全モデル統一の方針）。
 
-| パラメータ名 | type | low | high | log | 説明 |
-|------------|------|-----|------|-----|------|
-| `num_leaves` | `int` | 20 | 300 | False | 葉の最大数。過学習の主要な制御パラメータ |
-| `max_depth` | `int` | 3 | 12 | False | 木の最大深さ（-1 で無制限だが MVP では範囲指定） |
-| `learning_rate` | `float` | 1e-4 | 0.3 | True | 学習率。対数スケールで広い範囲を探索 |
-| `n_estimators` | `int` | 50 | 1000 | False | ブースティングの反復回数 |
-| `subsample` | `float` | 0.5 | 1.0 | False | 行サンプリング率 |
-| `colsample_bytree` | `float` | 0.5 | 1.0 | False | 列サンプリング率 |
-| `reg_alpha` | `float` | 1e-8 | 10.0 | True | L1 正則化係数 |
-| `reg_lambda` | `float` | 1e-8 | 10.0 | True | L2 正則化係数 |
+ハードコードされたデフォルト空間は廃止した。モデルの特性・試行回数・`eval_fn` の内容を LLM に渡すことで、ユースケースに応じた適切な探索空間が生成される。
 
 ---
 


### PR DESCRIPTION
## Summary

- `model_adapter_design.md` §3-1: パラメーター空間の決定ルールを実装に合わせて更新。`get_default_param_space()` ではなく `HPOAgent._generate_param_space()` による LLM 自動生成に委譲する旨を反映
- `model_adapter_design.md` §4-2: `LightGBMAdapter` のハードコードされた8パラメータのデフォルト空間を削除し、LLM 自動生成に委譲することを明記
- `impl_design.md`: 実装に存在しない `_report_progress()` メソッドの記述を、実際の `_tool_executor_node()` に統一（クラス定義・シーケンス図・データフロー図・Mermaid クラス図・実装注意点の計5箇所）

## Background

コードとドキュメントの整合性チェックで検出された以下の乖離を修正する。

1. `LightGBMAdapter.get_default_param_space()` が `NotImplementedError` を送出するにもかかわらず、ドキュメントが「8パラメータをデフォルト空間として定義する」と記述していた
2. `Supervisor._report_progress()` がドキュメントに定義されているが、実装では `_tool_executor_node()` 内に統合されており、独立したメソッドは存在しなかった

## Test plan

- [ ] ドキュメントのみの変更であり、テストコードへの影響なし
- [ ] `model_adapter_design.md` の §3-1・§4-2 が実装（`adapters.py`, `agent.py`）と整合していることを確認
- [ ] `impl_design.md` の Supervisor クラス定義・各図が `supervisor.py` の実装と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)