### PR TITLE
example: align example scripts with current API usage

### DIFF
--- a/example/s5e4_lgbm.py
+++ b/example/s5e4_lgbm.py
@@ -171,10 +171,11 @@ def main() -> None:
     print(f"最良パラメータ: {result.best_params}\n")
 
     # 試行履歴 CSV 出力
-    csv_path = pathlib.Path(__file__).parent / "output" / "s5e4_trials.csv"
+    output_dir = pathlib.Path(__file__).parent / "output"
+    output_dir.mkdir(exist_ok=True)
+    csv_path = output_dir / "s5e4_trials.csv"
     output_df = result.trials_df.copy()
-    if "score" in output_df.columns:
-        output_df["cv_rmse"] = -output_df["score"]
+    output_df["cv_rmse"] = -output_df["score"]
     output_df.to_csv(csv_path, index=False, encoding="utf-8")
     print(f"試行履歴を保存しました: {csv_path}\n")
 
@@ -185,9 +186,7 @@ def main() -> None:
     # Markdown レポート
     print("\n=== レポート ===")
     print(result.report)
-    with open(
-        pathlib.Path(__file__).parent / "output" / "s5e4_hpo_report.md", "w"
-    ) as f:
+    with open(output_dir / "s5e4_hpo_report.md", "w") as f:
         f.write(result.report)
 
 

--- a/example/simple_pytorch.py
+++ b/example/simple_pytorch.py
@@ -127,8 +127,8 @@ param_space = ParamSpace(
 # 部分指定: パラメータ名と型のみ指定し、範囲は LLM が補完する
 partial_param_space = ParamSpace(
     specs=(
-        ParamSpec(name="hidden_size", type="int"),  # 範囲は LLM が補完
-        ParamSpec(name="dropout", type="float"),  # 範囲は LLM が補完
+        ParamSpec(name="hidden_size", type="int", high=256),  # 範囲は LLM が補完
+        ParamSpec(name="dropout", type="float", low=0.0),  # 範囲は LLM が補完
     )
 )
 
@@ -180,7 +180,7 @@ def main() -> None:
         seed=42,
     )
 
-    print("Starting optimization (n_trials=15)...\n")
+    print("Starting optimization (n_trials=5)...\n")
     result = agent.run()
 
     print("\n=== Optimization Results ===")

--- a/example/titanic_lgbm.py
+++ b/example/titanic_lgbm.py
@@ -131,10 +131,11 @@ def main() -> None:
     print(f"バリデーション精度: {val_acc:.4f}\n")
 
     # 試行履歴 CSV 出力
-    csv_path = pathlib.Path(__file__).parent / "output" / "lgb_trials.csv"
+    output_dir = pathlib.Path(__file__).parent / "output"
+    output_dir.mkdir(exist_ok=True)
+    csv_path = output_dir / "lgb_trials.csv"
     output_df = result.trials_df.copy()
-    if "score" in output_df.columns:
-        output_df["acc"] = output_df["score"]
+    output_df["acc"] = output_df["score"]
     output_df.to_csv(csv_path, index=False, encoding="utf-8")
     print(f"試行履歴を保存しました: {csv_path}\n")
 
@@ -145,7 +146,7 @@ def main() -> None:
     # Markdown レポート
     print("\n=== レポート ===")
     print(result.report)
-    with open(pathlib.Path(__file__).parent / "output" / "lgb_hpo_report.md", "w") as f:
+    with open(output_dir / "lgb_hpo_report.md", "w") as f:
         f.write(result.report)
 
 


### PR DESCRIPTION
## Summary

- `simple_pytorch.py`: print 文の `n_trials` 値を実際の設定値（5）に修正、`partial_param_space` にユーザー指定バウンドを追加
- `titanic_lgbm.py`: `output_dir.mkdir(exist_ok=True)` を追加、パス構築を `output_dir` 変数に統一、不要な `if "score"` ガードを削除
- `s5e4_lgbm.py`: `titanic_lgbm.py` と同様の修正

## Test plan

- [ ] 各ファイルの `n_trials` 値と print 文が一致していること
- [ ] `output_dir.mkdir(exist_ok=True)` パターンが全4ファイルで統一されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)